### PR TITLE
fix: remove deprecated linkLibC and linkLibCpp

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,15 +28,14 @@ pub fn build(b: *std.Build) void {
     });
     module.addIncludePath(b.path("libs/cbullet"));
     module.addIncludePath(b.path("libs/bullet"));
+    module.linkSystemLibrary("c", .{});
+    module.linkSystemLibrary("c++", .{});
 
     const cbullet_lib = b.addLibrary(.{
         .name = "cbullet",
         .root_module = module,
     });
     b.installArtifact(cbullet_lib);
-
-    cbullet_lib.linkLibC();
-    cbullet_lib.linkLibCpp();
 
     const test_step = b.step("test", "Run zbullet tests");
 

--- a/build.zig
+++ b/build.zig
@@ -28,8 +28,9 @@ pub fn build(b: *std.Build) void {
     });
     module.addIncludePath(b.path("libs/cbullet"));
     module.addIncludePath(b.path("libs/bullet"));
-    module.linkSystemLibrary("c", .{});
-    module.linkSystemLibrary("c++", .{});
+
+    module.link_libc = true;
+    module.link_libcpp = true;
 
     const cbullet_lib = b.addLibrary(.{
         .name = "cbullet",

--- a/src/zbullet.zig
+++ b/src/zbullet.zig
@@ -1,6 +1,5 @@
 // Zig bindings for Bullet Physics SDK
 
-const builtin = @import("builtin");
 const std = @import("std");
 const Mutex = std.Thread.Mutex;
 const expect = std.testing.expect;


### PR DESCRIPTION
linkLibC and linkLibCpp are deprecated in zig 0.15.x, since this [commit](https://codeberg.org/ziglang/zig/commit/39fa8319478e4843d5384e81935520be2dbbadef?files=lib/std/Build/Step/Compile.zig).

Replacing it with `mod.linkSystemLibrary` should work, tested on my machine.